### PR TITLE
Fetch image URL from Fedora4

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+export FEDORA_URL=http://127.0.0.1:8984/rest/dev/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tmp/
 
 # Used by dotenv library to load environment variables.
-# .env
+.env
 
 ## Specific to RubyMotion:
 .dat*
@@ -48,3 +48,5 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.byebug_history

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  bixby: bixby_default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 gem 'bixby', '~> 1.0' # bixby == the samvera community's rubocop rules
+gem 'dotenv'
+gem 'ldp'
 gem 'rspec'
+gem 'vcr'
+gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,69 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
       rubocop-rspec (~> 1.22, <= 1.22.2)
+    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.0.5-java)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    deprecation (1.0.0)
+      activesupport
     diff-lcs (1.3)
+    dotenv (2.2.1)
+    ebnf (1.1.2)
+      rdf (>= 2.2, < 4.0)
+      sxp (~> 1.0)
+    faraday (0.12.2)
+      multipart-post (>= 1.2, < 3)
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    hashdiff (0.3.7)
+    http_logger (0.5.1)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    json-ld (2.2.1)
+      multi_json (~> 1.12)
+      rdf (>= 2.2.8, < 4.0)
+    ldp (0.7.0)
+      deprecation
+      faraday
+      http_logger
+      json-ld
+      rdf (>= 1.1)
+      rdf-isomorphic
+      rdf-turtle
+      rdf-vocab (>= 0.8)
+      slop
+    link_header (0.0.8)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
     parallel (1.12.1)
     parser (2.5.0.2)
       ast (~> 2.4.0)
     powerpack (0.1.1)
+    public_suffix (3.0.2)
     rainbow (3.0.0)
+    rdf (2.2.12)
+      hamster (~> 3.0)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-isomorphic (2.2.0)
+      rdf (>= 2.0, < 4.0)
+    rdf-turtle (2.2.2)
+      ebnf (~> 1.1)
+      rdf (>= 2.2, < 4.0)
+    rdf-vocab (2.2.9)
+      rdf (>= 2.2, < 4.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -34,7 +87,20 @@ GEM
     rubocop-rspec (1.22.2)
       rubocop (>= 0.52.1)
     ruby-progressbar (1.9.0)
+    safe_yaml (1.0.4)
+    slop (4.6.1)
+    sxp (1.0.1)
+      rdf (>= 2.2, < 4.0)
+    thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
+    vcr (4.0.0)
+    webmock (3.3.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   java
@@ -42,7 +108,11 @@ PLATFORMS
 
 DEPENDENCIES
   bixby (~> 1.0)
+  dotenv
+  ldp
   rspec
+  vcr
+  webmock
 
 BUNDLED WITH
    1.16.1

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ image fetching.
 ## Dependencies
 1. JRuby ~> 9.1
 2. Cantaloupe ~> 3.4
+
+## Environment Variables
+This project uses `dotenv` to set environment variables during local development. 
+Copy the sample dotenv file to `.env.development` and configure it for your local
+environment while you're doing local development.
+```
+cp dotenv.sample .env.development
+```
+
+For production use, set the environment variables as expected in your production 
+environment. See the `dotenv.sample` file for the list of environment variables
+expected.

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -1,0 +1,1 @@
+export FEDORA_URL=http://127.0.0.1:8984/rest/dev/

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -1,3 +1,6 @@
+require 'dotenv'
+Dotenv.load
+require 'ldp'
 ##
 # Cantaloupe delegate script configured for Fedora 4 and UCSB
 #
@@ -46,9 +49,20 @@ module Cantaloupe
     #         corresponding to the given identifier; or a hash with `uri`,
     #         `username`, and `secret` keys; or nil if not found.
     #
-    def self.get_url(identifier, context)
-      fedora_uri = ENV['FEDORA_URI']
-      true
+    def self.get_url(identifier, _context)
+      ldp_client = ::Ldp::Client.new(ENV['FEDORA_URL'])
+      fileset_uri = RDF::URI(Cantaloupe::HttpResolver.fileset_url(identifier))
+      ldp_container = ::Ldp::Container::Basic.new(ldp_client, fileset_uri)
+      has_file = ldp_container.graph.query([nil, RDF::URI('http://pcdm.org/models#hasFile'), nil])
+      has_file.map(&:object).first.to_s
+    end
+
+    def self.fileset_url(identifier)
+      "#{ENV['FEDORA_URL']}#{identifier[0, 2]}/#{identifier[2, 2]}/#{identifier[4, 2]}/#{identifier[6, 2]}/#{identifier}"
+    end
+
+    def self.fedora_url
+      ENV['FEDORA_URL']
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/fedora4query.yml
+++ b/spec/fixtures/vcr_cassettes/fedora4query.yml
@@ -1,0 +1,124 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:8984/rest/dev/9g/54/xh/65/9g54xh65x
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 13:13:26 GMT
+      Etag:
+      - W/"e150500feaa08bae889d2816b126dcc2477774b2"
+      Last-Modified:
+      - Wed, 07 Mar 2018 16:26:18 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4456'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://projecthydra.org/ns/mix/> .
+        @prefix ns021:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns026:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix ns004:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns003:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns025:  <http://open.vocab.org/terms/> .
+        @prefix ns002:  <http://purl.org/dc/terms/> .
+        @prefix ns024:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns023:  <http://pcdm.org/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <https://schema.org/> .
+        @prefix ns007:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns006:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://projecthydra.org/ns/odf/> .
+        @prefix ns027:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns005:  <http://vivoweb.org/ontology/core#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://purl.org/spar/fabio/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns015:  <http://pcdm.org/models#> .
+        @prefix ns014:  <http://projecthydra.org/works/models#> .
+        @prefix ns013:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns012:  <http://schema.org/> .
+        @prefix ns019:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns016:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8984/rest/dev/9g/54/xh/65/9g54xh65x>
+                rdf:type                fedora:Container ;
+                rdf:type                ns014:FileSet ;
+                rdf:type                fedora:Resource ;
+                rdf:type                ns015:Object ;
+                fedora:lastModifiedBy   "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns001:downloadFilename  "full_jpg.jpg"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                dc:format               "Image"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns001:hasModel          "FileSet"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns023:use               "supplementary"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns002:dateSubmitted     "2018-03-07T16:25:53.713354+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:createdBy        "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns006:dpt               "bess"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:lastModified     "2018-03-07T16:26:18.95Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created          "2018-03-07T16:25:54.302Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns002:modified          "2018-03-07T16:25:53.713354+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                dc:creator              "bess"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns003:accessControl     <http://127.0.0.1:8984/rest/dev/23/5a/3d/84/235a3d84-6d9a-4ac7-9479-513dfa27306c> ;
+                ns002:title             "NASA"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                dc:description          "stars forming"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                rdf:type                ldp:RDFSource ;
+                rdf:type                ldp:Container ;
+                fedora:writable         "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent        <http://127.0.0.1:8984/rest/dev> ;
+                ldp:contains            <http://127.0.0.1:8984/rest/dev/9g/54/xh/65/9g54xh65x/files> ;
+                ns015:hasFile           <http://127.0.0.1:8984/rest/dev/9g/54/xh/65/9g54xh65x/files/83ef8308-289e-4108-b30d-8640ce9e2e5f> .
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 13:13:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/http_resolver_spec.rb
+++ b/spec/http_resolver_spec.rb
@@ -1,8 +1,25 @@
 $LOAD_PATH << '../lib'
 require 'delegates.rb'
+require 'vcr'
+require 'webmock'
+
+ENV['FEDORA_URL'] = 'http://127.0.0.1:8984/rest/dev/'.freeze
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
 
 describe Cantaloupe::HttpResolver do
-  it 'accepts an id and returns a url' do
-    expect(Cantaloupe::HttpResolver.get_url('abc123', nil)).to eq 'https://fedora.info/blah'
+  it 'gets the fedora url' do
+    expect(described_class.fedora_url).to eq 'http://127.0.0.1:8984/rest/dev/'
+  end
+  it 'gets the fileset url' do
+    expect(described_class.fileset_url('9g54xh65x')).to eq 'http://127.0.0.1:8984/rest/dev/9g/54/xh/65/9g54xh65x'
+  end
+  it 'gets the file url' do
+    VCR.use_cassette("fedora4query") do
+      expect(described_class.get_url('9g54xh65x', nil)).to eq 'http://127.0.0.1:8984/rest/dev/9g/54/xh/65/9g54xh65x/files/83ef8308-289e-4108-b30d-8640ce9e2e5f'
+    end
   end
 end


### PR DESCRIPTION
Given a fileset id, get the fileset object from Fedora4.
Return the fileset's hasFile object.
Test with rspec, use vcr to record HTTP interactions.
Check style with Bixby.
Use JRuby, which is required by Cantaloupe.